### PR TITLE
changing has_change_permission to has_view_permission

### DIFF
--- a/subadmin/templates/subadmin/breadcrumbs.html
+++ b/subadmin/templates/subadmin/breadcrumbs.html
@@ -3,5 +3,5 @@
 <a href="{% url 'admin:index' %}">{% trans 'Home' %}</a>
 &rsaquo; <a href="{{ root.url }}">{{ root.name }}</a>
 {% for item in breadcrumbs %}
-&rsaquo; {% if item.has_change_permission %}<a href="{{ item.url }}">{{ item.name|capfirst }}</a>{% else %}{{ item.name|capfirst }}{% endif %}
+&rsaquo; {% if item.has_view_permission %}<a href="{{ item.url }}">{{ item.name|capfirst }}</a>{% else %}{{ item.name|capfirst }}{% endif %}
 {% endfor %}


### PR DESCRIPTION
Restricting Breadcrumb Button in Subadmin

This pull request addresses an issue related to the behavior of the breadcrumb button in the Subadmin. As there was no specific contribution guide available, I decided to open a small pull request instead of creating an issue, considering the simplicity of the change.

To provide some context, I utilized the Subadmin to create a read-only panel where field values cannot be modified, and new objects cannot be added or removed (I needed only the actions). However, I found that when I overrode the has_change_permission method of the Subadmin, the breadcrumb button, which should redirect me to the objects, disappeared.

In my perspective, it seems logical to hide the breadcrumb button only when the user lacks the permission to view objects, rather than modifying them.